### PR TITLE
fix: update webhook logger documentation

### DIFF
--- a/pages/resources/core/Modules.mdx
+++ b/pages/resources/core/Modules.mdx
@@ -27,7 +27,7 @@ logs to either discord or ox_lib depending on whether webhook is nil or not
 ---@field message string the message attached to the log
 ---@field webhook? string Discord logs only. url of the webhook this log should send to
 ---@field color? string Discord logs only. what color the message should be
----@field tags? string[] Discord logs only. tags in discord. Example: ['@admin', '@everyone']
+---@field tags? string[] Discord logs only. tags in discord. Example: {'<@&roleid>', '<@userid>', '@everyone'}
 ```
 
 ### Example use
@@ -39,5 +39,6 @@ logger.log({
   source = 'my source',
   event = 'my event',
   message = 'my message',
+  tags = {'@everyone'}
 })
 ```

--- a/pages/resources/core/Modules.mdx
+++ b/pages/resources/core/Modules.mdx
@@ -25,7 +25,7 @@ logs to either discord or ox_lib depending on whether webhook is nil or not
 ---@field source string source of the log. Usually a playerId or name of a resource.
 ---@field event string the action or 'event' being logged. Usually a verb describing what the name is doing. Example: SpawnVehicle
 ---@field message string the message attached to the log
----@field webhook? string Discord logs only. shortname of the webhook this log should send to. pulls url from configuration.
+---@field webhook? string Discord logs only. webhook this log should send to.
 ---@field color? string Discord logs only. what color the message should be
 ---@field tags? string[] Discord logs only. tags in discord. Example: {'<@&roleid>', '<@userid>', '@everyone'}
 ```

--- a/pages/resources/core/Modules.mdx
+++ b/pages/resources/core/Modules.mdx
@@ -25,7 +25,7 @@ logs to either discord or ox_lib depending on whether webhook is nil or not
 ---@field source string source of the log. Usually a playerId or name of a resource.
 ---@field event string the action or 'event' being logged. Usually a verb describing what the name is doing. Example: SpawnVehicle
 ---@field message string the message attached to the log
----@field webhook? string Discord logs only. webhook this log should send to.
+---@field webhook? string Discord logs only. url of the webhook this log should send to.
 ---@field color? string Discord logs only. what color the message should be
 ---@field tags? string[] Discord logs only. tags in discord. Example: {'<@&roleid>', '<@userid>', '@everyone'}
 ```

--- a/pages/resources/core/Modules.mdx
+++ b/pages/resources/core/Modules.mdx
@@ -25,7 +25,7 @@ logs to either discord or ox_lib depending on whether webhook is nil or not
 ---@field source string source of the log. Usually a playerId or name of a resource.
 ---@field event string the action or 'event' being logged. Usually a verb describing what the name is doing. Example: SpawnVehicle
 ---@field message string the message attached to the log
----@field webhook? string Discord logs only. url of the webhook this log should send to
+---@field webhook? string Discord logs only. shortname of the webhook this log should send to. pulls url from configuration.
 ---@field color? string Discord logs only. what color the message should be
 ---@field tags? string[] Discord logs only. tags in discord. Example: {'<@&roleid>', '<@userid>', '@everyone'}
 ```


### PR DESCRIPTION
Tagging roles in discord is weird. This gives more descriptive documentation for how to ping roles and users/channels