### PR TITLE
docs(pages): standardize content and add missing qbx_core exports

### DIFF
--- a/pages/converting.mdx
+++ b/pages/converting.mdx
@@ -14,7 +14,7 @@
   You can continue using `exports['qb-core']`, however, this means you won't get access to all the new Qbox features and functions, so consider switching off of `exports['qb-core']` when you can.
   Do note that undocumented and invalid usages of qb-core are not supported and may not be in the future.
   See the [FAQ](./faq#will-my-qbcore-scripts-work-with-qbox) for more details.
-6. Qbox has a multijob/gang system built into core that cannot be disabled. By default, players may only be in one job & gang. This can be overriden by setting `qbx:max_jobs_per_player` and `qbx:max_gangs_per_player` in server.cfg. 
+6. Qbox has a multijob/gang system built into core that cannot be disabled. By default, players may only be in one job & gang. This can be overriden by setting `qbx:max_jobs_per_player` and `qbx:max_gangs_per_player` in server.cfg.
   Do not use an external multijob/gang resource that isn't guaranteed by the developer to be Qbox compatible.
   Using incompatible multijobs or resources which modify core's database tables may lead to data corruption. First, double check that the player.citizenid column in your database has collation `utf8mb4_unicode_ci`. If not, change it.
   Then, run qbx_core.sql to create the new player_groups table. Start the server and type `convertjobs` into the txAdmin console once the server is running to populate the player_groups table.

--- a/pages/resources/qbx_core/exports/server.mdx
+++ b/pages/resources/qbx_core/exports/server.mdx
@@ -615,3 +615,72 @@ exports.qbx_core:RemoveGangGrade(gangName, grade)
 - gangName: `string`
 - grade: `integer`
 
+## SetPlayerPrimaryJob
+
+Sets the given player's primary job to the given job, only if they already have it.
+
+```lua
+exports.qbx_core:SetPlayerPrimaryJob(citizenid, jobName)
+```
+
+- citizenid: `string`
+- jobName: `string`
+
+## AddPlayerToJob
+
+Adds the given player to the given job, or overwrites their grade if they're already in that job.
+
+```lua
+exports.qbx_core:AddPlayerToJob(citizenid, jobName, grade)
+```
+
+- citizenid: `string`
+- jobName: `string`
+- grade: `integer`
+
+## RemovePlayerFromJob
+
+Removes the given player from the given job.
+Also updates the given player's primary job to unemployed if the given job is the player's primary.
+
+```lua
+exports.qbx_core:RemovePlayerFromJob(citizenid, jobName)
+```
+
+- citizenid: `string`
+- jobName: `string`
+
+## SetPlayerPrimaryGang
+
+Sets the given player's primary gang to the given gang, only if they already have it.
+
+```lua
+exports.qbx_core:SetPlayerPrimaryGang(citizenid, gangName)
+```
+
+- citizenid: `string`
+- gangName: `string`
+
+## AddPlayerToGang
+
+Adds the given player to the given gang, or overwrites their grade if they're already in that gang.
+
+```lua
+exports.qbx_core:AddPlayerToGang(citizenid, gangName, grade)
+```
+
+- citizenid: `string`
+- gangName: `string`
+- grade: `integer`
+
+## RemovePlayerFromGang
+
+Removes the given player from the given gang.
+Also updates the given player's primary gang to no gang if the given gang is the player's primary.
+
+```lua
+exports.qbx_core:RemovePlayerFromGang(citizenid, gangName)
+```
+
+- citizenid: `string`
+- gangName: `string`

--- a/pages/resources/qbx_core/exports/server.mdx
+++ b/pages/resources/qbx_core/exports/server.mdx
@@ -496,24 +496,26 @@ Returns unique values for player identifiers.
 ```lua
 exports.qbx_core:GenerateUniqueIdentifier(type)
 ```
+
 - type: `'citizenid' | 'AccountNumber' | 'PhoneNumber' | 'FingerId' | 'WalletId' | 'SerialNumber'`
 
 Returns: `string | number`
 
 ## GetJob
 
-Returns the job if it exists
+Returns the given job if it exists.
 
 ```lua
 exports.qbx_core:GetJob(jobName)
-``` 
+```
+
 - jobName: `string`
 
 Returns: `Job?`
 
 ## GetGang
 
-Returns the gang if it exists
+Returns the given gang if it exists.
 
 ```lua
 exports.qbx_core:GetGang(gangName)
@@ -524,30 +526,41 @@ Returns: `Gang?`
 
 ## UpsertJobData
 
-Inserts or overwrites fields of a job temporarily. The changes are not \
-persisted after a restart.
+Inserts or overwrites fields of the given job temporarily.
+
+<Callout type='warning'>
+  This is a runtime-only change. This won't persist across restarts and won't modify files.
+</Callout>
 
 ```lua
 exports.qbx_core:UpsertJobData(jobName, data)
 ```
+
 - jobName: `string`
 - data: `JobData`
 
 ## UpsertGangData
 
-Inserts or overwrites fields of a gang temporarily. The changes are not \
-persisted after a restart.
+Inserts or overwrites fields of the given gang temporarily.
+
+<Callout type='warning'>
+  This is a runtime-only change. This won't persist across restarts and won't modify files.
+</Callout>
 
 ```lua
 exports.qbx_core:UpsertGangData(gangName, data)
 ```
+
 - gangName: `string`
 - data: `GangData`
 
 ## UpsertJobGrade
 
-Inserts or overwrites fields of a job's grade temporarily. The changes are not \
-persisted after a restart.
+Inserts or overwrites fields of the given job's grade temporarily.
+
+<Callout type='warning'>
+  This is a runtime-only change. This won't persist across restarts and won't modify files.
+</Callout>
 
 ```lua
 exports.qbx_core:UpsertJobGrade(jobName, grade, data)
@@ -558,33 +571,47 @@ exports.qbx_core:UpsertJobGrade(jobName, grade, data)
 
 ## UpsertGangGrade
 
-Inserts or overwrites fields of a gang's grade temporarily. The changes are not \
-persisted after a restart.
+Inserts or overwrites fields of the given gang's grade temporarily.
+
+<Callout type='warning'>
+  This is a runtime-only change. This won't persist across restarts and won't modify files.
+</Callout>
 
 ```lua
 exports.qbx_core:UpsertGangGrade(gangName, grade, data)
 ```
+
 - gangName: `string`
 - grade: `integer`
 - data: `GangGradeData`
 
 ## RemoveJobGrade
 
-Removes a job's grade temporarily. The changes are notpersisted after a restart.
+Removes the given job's grade temporarily.
+
+<Callout type='warning'>
+  This is a runtime-only change. This won't persist across restarts and won't modify files.
+</Callout>
 
 ```lua
 exports.qbx_core:RemoveJobGrade(jobName, grade)
 ```
+
 - jobName: `string`
 - grade: `integer`
 
 ## RemoveGangGrade
 
-Removes a gang's grade temporarily. The changes are not persisted after a restart.
+Removes the given gang's grade temporarily.
+
+<Callout type='warning'>
+  This is a runtime-only change. This won't persist across restarts and won't modify files.
+</Callout>
 
 ```lua
 exports.qbx_core:RemoveGangGrade(gangName, grade)
 ```
+
 - gangName: `string`
 - grade: `integer`
 

--- a/pages/resources/qbx_core/types/gang.mdx
+++ b/pages/resources/qbx_core/types/gang.mdx
@@ -1,21 +1,7 @@
 # Gang
 
-Extends: `GangData`
+Extends: [`GangData`](./gang_data)
 
 ## Fields
 
 - grades: `table<integer, GangGradeData>`
-
-# GangData
-
-## Fields
-
-- label: `string`
-
-# GangGradeData
-
-## Fields
-
-- name: `string`
-- isboss?: `boolean`
-- bankAuth?: `boolean`

--- a/pages/resources/qbx_core/types/gang_data.mdx
+++ b/pages/resources/qbx_core/types/gang_data.mdx
@@ -1,0 +1,5 @@
+# GangData
+
+## Fields
+
+- label: `string`

--- a/pages/resources/qbx_core/types/gang_grade_data.mdx
+++ b/pages/resources/qbx_core/types/gang_grade_data.mdx
@@ -1,0 +1,7 @@
+# GangGradeData
+
+## Fields
+
+- name: `string`
+- isboss?: `boolean`
+- bankAuth?: `boolean`

--- a/pages/resources/qbx_core/types/job.mdx
+++ b/pages/resources/qbx_core/types/job.mdx
@@ -1,25 +1,7 @@
 # Job
 
-Extends: `JobData`
+Extends: [`JobData`](./job_data)
 
 ## Fields
 
 - grades: `table<integer, JobGradeData>`
-
-# JobData
-
-## Fields
-
-- label: `string`
-- type?: `string`
-- defaultDuty: `boolean`
-- offDutyPay: `boolean`
-
-# JobGradeData
-
-## Fields
-
-- name: `string`
-- isboss?: `boolean`
-- bankAuth?: `boolean`
-- payment: `number`

--- a/pages/resources/qbx_core/types/job_data.mdx
+++ b/pages/resources/qbx_core/types/job_data.mdx
@@ -1,0 +1,8 @@
+# JobData
+
+## Fields
+
+- label: `string`
+- type?: `string`
+- defaultDuty: `boolean`
+- offDutyPay: `boolean`

--- a/pages/resources/qbx_core/types/job_grade_data.mdx
+++ b/pages/resources/qbx_core/types/job_grade_data.mdx
@@ -1,0 +1,8 @@
+# JobGradeData
+
+## Fields
+
+- name: `string`
+- isboss?: `boolean`
+- bankAuth?: `boolean`
+- payment: `number`

--- a/pages/resources/qbx_core/types/player.mdx
+++ b/pages/resources/qbx_core/types/player.mdx
@@ -10,7 +10,7 @@
 
 ### SetJob
 
-Attempts to set the player's job with the given grade, and returns whether it was successful.
+Attempts to overwrite the player's primary job and grade, and returns whether it was successful.
 
 ```lua
 Player.Functions.SetJob(jobName, grade)
@@ -23,7 +23,7 @@ Returns: `boolean`
 
 ### SetGang
 
-Attempts to set the player's gang with the given grade, and returns whether it was successful.
+Attempts to overwrite the player's primary gang and grade, and returns whether it was successful.
 
 ```lua
 Player.Functions.SetGang(gangName, grade)


### PR DESCRIPTION
The goal of this PR is mainly to document exports added in [qbx_core v1.7.0](https://github.com/Qbox-project/qbx_core/releases/tag/v1.7.0) that are not yet documented.

In addition this standardizes the content added by #18 to be similar to content already available in the documentation.
