### PR TITLE
feat(client/management): missing OpenBossMenu export

### DIFF
--- a/pages/resources/qbx_management/exports/client.mdx
+++ b/pages/resources/qbx_management/exports/client.mdx
@@ -1,0 +1,13 @@
+import { Callout } from 'nextra/components';
+
+# Client Exports
+
+## RegisterBossMenu
+
+Open the primary job or gang boss menu as long as you have the proper permissions.
+
+```lua
+exports.qbx_management:OpenBossMenu(groupType)
+```
+
+- groupType: `'gang' | 'job'`


### PR DESCRIPTION
This adds the missing OpenBossMenu export for qbx_management