### PR TITLE
docs(qbx_core/modules/lib/client): updated drawText params

### DIFF
--- a/pages/resources/qbx_core/modules/lib/client.mdx
+++ b/pages/resources/qbx_core/modules/lib/client.mdx
@@ -22,6 +22,10 @@ qbx.drawText2d(params)
     - Default: `1.0`
   - height?: `number`
     - Default: `1.0`
+  - enableDropShadow?: `boolean`
+    - Enables a black drop shadow for the text.
+  - enableOutline?: `boolean`
+    - Enables a black outline for the text.
 
 ## drawText3d
 
@@ -35,14 +39,18 @@ qbx.drawText3d(params)
   - text: `string`
   - coords: `vector3`
     - In-world coordinates.
-  - scale?: `integer`
-    - Default: `0.35`
+  - scale?: `vector2`
+    - Default: `vec2(0.35, 0.35)`
   - font?: `integer`
     - Default: `4`
   - color?: `vector4`
     - An RGBA value; white by default.
   - disableDrawRect?: `boolean`
     - Disables drawing a rectangle background for the text.
+  - enableDropShadow?: `boolean`
+    - Enables a black drop shadow for the text.
+  - enableOutline?: `boolean`
+    - Enables a black outline for the text.
 
 ## getEntityAndNetIdFromBagName
 

--- a/pages/resources/qbx_core/modules/lib/client.mdx
+++ b/pages/resources/qbx_core/modules/lib/client.mdx
@@ -39,7 +39,8 @@ qbx.drawText3d(params)
   - text: `string`
   - coords: `vector3`
     - In-world coordinates.
-  - scale?: `vector2`
+  - scale?: `integer` | `vector2`
+    - Use a integer to scale uniformly or use a vec2 to scale x and y different amounts.
     - Default: `vec2(0.35, 0.35)`
   - font?: `integer`
     - Default: `4`


### PR DESCRIPTION
- added `enableOutline` and `enableDropShadow` params to `qbx.drawText2d` and `qbx.drawText3d`

Made to reflect the changes made in [this](https://github.com/Qbox-project/qbx_core/pull/617) pull request